### PR TITLE
Updated cauterize parsers use to released Hackage version of s-cargot

### DIFF
--- a/src/Cauterize/Schema/Parser.hs
+++ b/src/Cauterize/Schema/Parser.hs
@@ -6,10 +6,8 @@ module Cauterize.Schema.Parser
   ) where
 
 import Control.Monad
-import Data.SCargot.General
-import Data.SCargot.Repr
+import Data.SCargot
 import Data.SCargot.Repr.WellFormed
-import Data.SCargot.Pretty
 import Data.SCargot.Comments
 import Data.Text (Text, pack, unpack)
 import qualified Data.Text as T
@@ -180,8 +178,8 @@ fromComponent c =
   where
     ident = A . Ident . pack
 
-cauterizeSpec :: SExprSpec Atom Component
-cauterizeSpec = convertSpec toComponent fromComponent $ withLispComments $ asWellFormed $ mkSpec pAtom sAtom
+cauterizeParser :: SExprParser Atom Component
+cauterizeParser = setCarrier toComponent $ withLispComments $ asWellFormed $ mkParser pAtom
 
 componentsToSchema :: [Component] -> Schema
 componentsToSchema = foldl go defaultSchema
@@ -198,10 +196,10 @@ schemaToComponents s =
   : map TypeDef (schemaTypes s)
 
 parseSchema :: Text -> Either String Schema
-parseSchema t = componentsToSchema `fmap` decode cauterizeSpec t
+parseSchema t = componentsToSchema `fmap` decode cauterizeParser t
 
 formatSchema :: IsSchema a => a -> Text
-formatSchema s = let pp = prettyPrintSExpr (basicPrint sAtom)
+formatSchema s = let pp = encodeOne (basicPrint sAtom)
                      s' = map (pp . fromWellFormed . fromComponent) (schemaToComponents (getSchema s))
                  in T.unlines s'
 

--- a/src/Cauterize/Specification/Parser.hs
+++ b/src/Cauterize/Specification/Parser.hs
@@ -6,10 +6,8 @@ module Cauterize.Specification.Parser
   ) where
 
 import Control.Monad
-import Data.SCargot.General
-import Data.SCargot.Repr
+import Data.SCargot
 import Data.SCargot.Repr.WellFormed
-import Data.SCargot.Pretty
 import Data.Text (Text, pack, unpack)
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
@@ -264,8 +262,8 @@ fromType (Type n f s d) = L (A (Ident "type") : rest)
         Union fs t ->
           [na, ai "union", fl, sl, at t, L (ai "fields" : map fromField fs)]
 
-cauterizeSpec :: SExprSpec Atom Component
-cauterizeSpec = convertSpec toComponent fromComponent $ asWellFormed $ mkSpec pAtom sAtom
+cauterizeParser :: SExprParser Atom Component
+cauterizeParser = setCarrier toComponent $ asWellFormed $ mkParser pAtom
 
 componentsToSpec :: [Component] -> Specification
 componentsToSpec cs = spec { specTypes = reverse $ specTypes spec }
@@ -294,10 +292,10 @@ specToComponents s =
 
 
 parseSpecification :: Text -> Either String Specification
-parseSpecification t = componentsToSpec `fmap` decode cauterizeSpec t
+parseSpecification t = componentsToSpec `fmap` decode cauterizeParser t
 
 formatSpecification :: Specification -> Text
-formatSpecification s = let pp = prettyPrintSExpr (basicPrint sAtom)
+formatSpecification s = let pp = encodeOne (basicPrint sAtom)
                             s' = map (pp . fromWellFormed . fromComponent) (specToComponents s)
                         in T.unlines s'
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,8 +1,6 @@
 flags: {}
 packages:
 - '.'
-- location:
-    git: https://github.com/aisamanra/s-cargot.git
-    commit: 1628a7c2913fc5e72ab6ea9a813762bf86d47d49
-extra-deps: []
+extra-deps:
+  - s-cargot-0.1.0.0
 resolver: lts-2.21


### PR DESCRIPTION
The changes are mostly small renamings and refactorings; the "biggest" change is that the `SExprSpec` type which described serialization/deserialization is now split apart into a `SExprPrinter` and a `SExprParser` type, but even that is relatively small, so these changes are mostly pretty minimal.
