### PR TITLE
add `stack setup` to the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ test:
 	@stack test
 
 install:
+	stack setup
 	stack build
 	mkdir -p $(INSTALL_DIR)
 	cp `stack path --dist-dir`/build/cauterize/cauterize \


### PR DESCRIPTION
which bootstraps stack on systems which may have fetched this repo as a
dependency
