### PR TITLE
makefile installation fix for windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,12 @@
 INSTALL_DIR?=$(HOME)/.local/bin
 export PATH := $(INSTALL_DIR):$(PATH)
 
+ifeq ($(OS),Windows_NT)
+	EXECUTABLE=$(shell stack path --dist-dir)\build\cauterize\cauterize.exe
+else
+	EXECUTABLE=$(shell stack path --dist-dir)/build/cauterize/cauterize
+endif
+
 .PHONY: default clean build test
 
 default: test
@@ -19,5 +25,4 @@ install:
 	stack setup
 	stack build
 	mkdir -p $(INSTALL_DIR)
-	cp `stack path --dist-dir`/build/cauterize/cauterize \
-		$(INSTALL_DIR)/cauterize
+	cp $(EXECUTABLE) $(INSTALL_DIR)


### PR DESCRIPTION
the Makefile we use to install cauterize automatically as part of some Helium builds has been modified to work correctly under windows.