### PR TITLE
Adjust index generation to be 1 based.

### DIFF
--- a/cauterize.cabal
+++ b/cauterize.cabal
@@ -1,5 +1,5 @@
 name:                cauterize
-version:             1.0.0.0
+version:             1.1.0.0
 synopsis:            Compiler for the Cauterize data description language.
 description:
   Cauterize is a data-description language suitable for hard-real-time systems

--- a/src/Cauterize/Schema/Util.hs
+++ b/src/Cauterize/Schema/Util.hs
@@ -147,9 +147,15 @@ tagForType (Type _ d) =
     Record _        -> error "No tag for records."
     Range _ l       -> tagRequired l
     Vector _ l      -> tagRequired l
-    Enumeration vs  -> tagRequired (length vs)
     Combination fs  -> tagForBits (length fs)
-    Union fs        -> tagRequired (length fs)
+
+    -- For enumerations and unions, we add one to the length because
+    -- we do not allow tags for these two prototypes with a value of
+    -- 0. This is to avoid a common class of errors where a
+    -- default-initialized struct/enum in C is 0. This helps catch
+    -- cases where the user forgot to initialize the tag.
+    Enumeration vs  -> tagRequired (length vs + 1)
+    Union fs        -> tagRequired (length fs + 1)
 
 
 primHashMap :: M.Map Identifier (T.Text,Hash)

--- a/tests/Cauterize/Specification/CompileSpec.hs
+++ b/tests/Cauterize/Specification/CompileSpec.hs
@@ -1,0 +1,132 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Cauterize.Specification.CompileSpec
+       ( spec
+       ) where
+
+import Cauterize.Specification.Types
+import Cauterize.Schema.Parser
+import Cauterize.Specification.Compile
+import Cauterize.CommonTypes
+import Test.Hspec
+
+import qualified Data.Text as T
+import qualified Data.List as L
+
+
+comp :: T.Text -> Either String Specification
+comp p = either (\e -> Left e)
+                (\s -> Right (mkSpecification s))
+                (parseSchema p)
+
+spec :: Spec
+spec = do
+  describe "compile" $ do
+    it "produces a synonym" $ do
+      let c = comp synFoo
+      c `shouldSatisfy` typeNameIs "foo"
+      c `shouldSatisfy` typeIsSynonym
+    it "produces an enumeration" $ do
+      let c = comp enumBar
+      c `shouldSatisfy` typeNameIs "bar"
+      c `shouldSatisfy` typeIsEnumeration
+      enumIndicies c `shouldBe` [1..4]
+    it "produces a union" $ do
+      let c = comp unionBaz
+      c `shouldSatisfy` typeNameIs "baz"
+      c `shouldSatisfy` typeIsUnion
+      unionIndicies c `shouldBe` [1..2]
+    it "produces a record" $ do
+      let c = comp recordFizz
+      c `shouldSatisfy` typeNameIs "fizz"
+      c `shouldSatisfy` typeIsRecord
+      recordIndicies c `shouldBe` [1..3]
+
+    it "picks the right tag type (T1)" $ do
+      let c = comp (enumLong 254)
+      c `shouldSatisfy` typeNameIs "long"
+      c `shouldSatisfy` typeIsEnumeration
+      enumIndicies c `shouldBe` [1..254]
+      enumTag c `shouldBe` Just T1
+
+    it "picks the right tag type (T2)" $ do
+      let c = comp (enumLong 255)
+      c `shouldSatisfy` typeNameIs "long"
+      c `shouldSatisfy` typeIsEnumeration
+      enumIndicies c `shouldBe` [1..255]
+      enumTag c `shouldBe` Just T2
+
+synFoo :: T.Text
+synFoo = "(type foo synonym u8)"
+
+enumBar :: T.Text
+enumBar = "(type bar enumeration (values a b c d))"
+
+enumLong :: Int -> T.Text
+enumLong 0 = error "Must not be 0."
+enumLong c = let prefix = "(type long enumeration (values "
+                 vals = map (\v -> "v_" ++ show v) (take c [0..] :: [Int])
+                 valstr = concat $ L.intersperse " " vals
+                 postfix = "))"
+             in prefix `T.append` T.pack valstr `T.append` postfix
+
+unionBaz :: T.Text
+unionBaz = "(type baz union (fields (field a u32) (field b u16)))"
+
+recordFizz :: T.Text
+recordFizz = "(type fizz record (fields (field a u32) (field b u16) (field c f32)))"
+
+
+typeNameIs :: Identifier -> Either a Specification -> Bool
+typeNameIs n (Right (Specification { specTypes = [ Type { typeName = name } ] })) = n == name
+typeNameIs _ _ = False
+
+typeIsSynonym :: Either a Specification -> Bool
+typeIsSynonym (Right
+               (Specification { specTypes = [ Type { typeDesc = Synonym {} } ] })) = True
+typeIsSynonym _ = False
+
+typeIsEnumeration :: Either a Specification -> Bool
+typeIsEnumeration (Right
+                   (Specification { specTypes = [ Type { typeDesc = Enumeration {} } ] })) = True
+typeIsEnumeration _ = False
+
+typeIsUnion :: Either a Specification -> Bool
+typeIsUnion (Right
+             (Specification { specTypes = [ Type { typeDesc = Union {} } ] })) = True
+typeIsUnion _ = False
+
+typeIsRecord :: Either a Specification -> Bool
+typeIsRecord (Right
+              (Specification { specTypes = [ Type { typeDesc = Record {} } ] })) = True
+typeIsRecord _ = False
+
+enumIndicies :: Either a Specification -> [Integer]
+enumIndicies (Right (Specification { specTypes = [ Type { typeDesc = desc } ] } ) ) =
+  case desc of
+    Enumeration { enumerationValues = vals } -> map getIndex vals
+    _ -> []
+  where
+    getIndex (EnumVal { enumValIndex = i }) = i
+enumIndicies _ = []
+
+unionIndicies :: Either a Specification -> [Integer]
+unionIndicies (Right (Specification { specTypes = [ Type { typeDesc = desc } ] } ) ) =
+  case desc of
+    Union { unionFields = fs } -> map fieldIndex fs
+    _ -> []
+unionIndicies _ = []
+
+recordIndicies :: Either a Specification -> [Integer]
+recordIndicies (Right (Specification { specTypes = [ Type { typeDesc = desc } ] } ) ) =
+  case desc of
+    Record { recordFields = fs } -> map fieldIndex fs
+    _ -> []
+recordIndicies _ = []
+
+
+enumTag :: Either a Specification -> Maybe Tag
+enumTag (Right (Specification { specTypes = [ Type { typeDesc = desc } ] } ) ) =
+  case desc of
+    Enumeration { enumerationTag = t } -> Just t
+    _ -> Nothing
+enumTag _ = Nothing


### PR DESCRIPTION
Adjust how indicies are generated for fields and enumeration values. The indicies now start with 1 rather than 0. This prevents typical default initializers in C from accidentally being a valid case.

This PR also changes how fingerprints are generated by adding content to each hashed string consisting of the major and minor cauterize versions. This helps prevent cases where specifications generated with two different Cauterize versions could mistakenly resolve to the same hash.